### PR TITLE
Serializable refactorings + import organization

### DIFF
--- a/src/main/java/de/beyondjava/jsf/sample/carshop/DynamicOptionBean.java
+++ b/src/main/java/de/beyondjava/jsf/sample/carshop/DynamicOptionBean.java
@@ -18,7 +18,6 @@ package de.beyondjava.jsf.sample.carshop;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/de/beyondjava/jsf/sample/carshop/FilterBean.java
+++ b/src/main/java/de/beyondjava/jsf/sample/carshop/FilterBean.java
@@ -30,8 +30,10 @@ import net.bootsfaces.beans.ELTools;
 @ManagedBean
 @SessionScoped
 public class FilterBean implements Serializable {
-	private static final Logger LOGGER = Logger.getLogger("de.beyondjava.jsf.sample.carshop.FilterBean");
-	
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger("de.beyondjava.jsf.sample.carshop.FilterBean");
+
 	private String brand;
 
 	@ManagedProperty("#{carPool}")

--- a/src/main/java/de/beyondjava/jsf/sample/carshop/StaticOptionBean.java
+++ b/src/main/java/de/beyondjava/jsf/sample/carshop/StaticOptionBean.java
@@ -19,12 +19,7 @@ package de.beyondjava.jsf.sample.carshop;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;

--- a/src/main/java/net/bootsfaces/demo/CarBean.java
+++ b/src/main/java/net/bootsfaces/demo/CarBean.java
@@ -28,7 +28,9 @@ import javax.validation.constraints.NotNull;
 @RequestScoped
 @ManagedBean
 public class CarBean implements Serializable {
-	@NotNull
+    private static final long serialVersionUID = 1L;
+
+    @NotNull
 	private String brand=null;
 
 	@NotNull

--- a/src/main/java/net/bootsfaces/demo/ClockBean.java
+++ b/src/main/java/net/bootsfaces/demo/ClockBean.java
@@ -9,8 +9,6 @@ import java.util.Calendar;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 
 /**
  * @author Stephan Rauh, http://www.beyondjava.net

--- a/src/main/java/net/bootsfaces/demo/ItemBean.java
+++ b/src/main/java/net/bootsfaces/demo/ItemBean.java
@@ -13,7 +13,8 @@ import javax.faces.model.DataModel;
 @ManagedBean
 @RequestScoped
 public class ItemBean implements Serializable {
-    
+    private static final long serialVersionUID = 1L;
+
     private static final Item[] itemList = new Item[]{
         new Item("Pencil","P3245","0,49 $"),
         new Item("Book","B0563","4,95 $"),

--- a/src/main/java/net/bootsfaces/demo/LoginBean.java
+++ b/src/main/java/net/bootsfaces/demo/LoginBean.java
@@ -4,9 +4,6 @@ import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
 import javax.faces.context.FacesContext;
-import javax.imageio.spi.ServiceRegistry;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.NotEmpty;

--- a/src/main/java/net/bootsfaces/demo/LoremIpsumBean.java
+++ b/src/main/java/net/bootsfaces/demo/LoremIpsumBean.java
@@ -20,7 +20,8 @@ import javax.faces.model.DataModel;
 @ManagedBean
 @RequestScoped
 public class LoremIpsumBean implements Serializable {
-    
+    private static final long serialVersionUID = 1L;
+
     public static final String loremipsum="Lorem ipsum dolor sit amet "
             + "consectetur adipiscing elit sed "
             + "do eiusmod tempor incididunt "

--- a/src/main/java/net/bootsfaces/demo/PanelBean.java
+++ b/src/main/java/net/bootsfaces/demo/PanelBean.java
@@ -6,11 +6,8 @@ package net.bootsfaces.demo;
 
 import java.io.Serializable;
 
-import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
-import javax.faces.bean.RequestScoped;
 import javax.faces.bean.SessionScoped;
-import javax.faces.context.FacesContext;
 import javax.faces.event.ActionEvent;
 
 /**

--- a/src/main/java/net/bootsfaces/demo/PollDemoBean.java
+++ b/src/main/java/net/bootsfaces/demo/PollDemoBean.java
@@ -10,9 +10,10 @@ import javax.faces.event.ActionEvent;
 @RequestScoped
 @ManagedBean
 public class PollDemoBean implements Serializable {
-	
-	private int counter=0;
-	
+    private static final long serialVersionUID = 1L;
+
+    private int counter=0;
+
 	public Date getCurrentTime() { return new Date(); }
 
 	public int getCounter() {

--- a/src/main/java/net/bootsfaces/demo/SelectMultiMenuBean.java
+++ b/src/main/java/net/bootsfaces/demo/SelectMultiMenuBean.java
@@ -28,7 +28,9 @@ import javax.validation.constraints.NotNull;
 @RequestScoped
 @ManagedBean
 public class SelectMultiMenuBean implements Serializable {
-	@NotNull
+    private static final long serialVersionUID = 1L;
+
+    @NotNull
 	private String brand=null;
 
 	@NotNull

--- a/src/main/java/net/bootsfaces/demo/SelectOneMenuBean.java
+++ b/src/main/java/net/bootsfaces/demo/SelectOneMenuBean.java
@@ -24,7 +24,6 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import net.bootsfaces.component.messages.Messages;
 import net.bootsfaces.utils.FacesMessages;
 
 /** A simple bean for demo purposes. */

--- a/src/main/java/net/bootsfaces/demo/SelectOneMenuBean.java
+++ b/src/main/java/net/bootsfaces/demo/SelectOneMenuBean.java
@@ -30,7 +30,6 @@ import net.bootsfaces.utils.FacesMessages;
 @RequestScoped
 @ManagedBean
 public class SelectOneMenuBean implements Serializable {
-
 	private static final long serialVersionUID = 1L;
 
 	@NotNull

--- a/src/main/java/net/bootsfaces/demo/SemaphoreBean.java
+++ b/src/main/java/net/bootsfaces/demo/SemaphoreBean.java
@@ -31,7 +31,9 @@ import javax.validation.constraints.NotNull;
 @RequestScoped
 @ManagedBean
 public class SemaphoreBean implements Serializable {
-	@NotNull
+    private static final long serialVersionUID = 1L;
+
+    @NotNull
 	private String color = null;
 
 	@NotNull

--- a/src/main/java/net/bootsfaces/demo/TestBean.java
+++ b/src/main/java/net/bootsfaces/demo/TestBean.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
-import javax.faces.event.ActionEvent;
 
 /**
  *

--- a/src/main/java/net/bootsfaces/demo/ajax/AjaxBean.java
+++ b/src/main/java/net/bootsfaces/demo/ajax/AjaxBean.java
@@ -1,5 +1,6 @@
 package net.bootsfaces.demo.ajax;
 
+import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -12,10 +13,11 @@ import javax.faces.context.FacesContext;
 
 @ManagedBean
 @ViewScoped
-public class AjaxBean {
-	
-	private List<String> messages = new ArrayList<>();
-	
+public class AjaxBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private List<String> messages = new ArrayList<>();
+
 	public AjaxBean() {
 		getMessages().add("No message yet.");
 		getMessages().add("Play with the AJAXified widget to add messages.");

--- a/src/main/java/net/bootsfaces/demo/ajax/CommandButtonBean.java
+++ b/src/main/java/net/bootsfaces/demo/ajax/CommandButtonBean.java
@@ -1,5 +1,6 @@
 package net.bootsfaces.demo.ajax;
 
+import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -8,8 +9,10 @@ import javax.faces.bean.ViewScoped;
 
 @ViewScoped
 @ManagedBean
-public class CommandButtonBean {
-	private String message = "No action listener called yet.";
+public class CommandButtonBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String message = "No action listener called yet.";
 
 	private boolean suppressClick = true;
 	private boolean suppressDoubleClick = false;


### PR DESCRIPTION
Some beans were `ViewScoped`, but not `Serializable`, which yields a server-side warning.
Most of the existing `serialVersionUID` aren't generated, but simply set to `1`, so i defaulted to that.
On the way I removed unused imports.
