### PR TITLE
Link to Moment.js documentation for date formats

### DIFF
--- a/src/main/webapp/forms/DateTimePickerAttributes.xhtml
+++ b/src/main/webapp/forms/DateTimePickerAttributes.xhtml
@@ -110,7 +110,7 @@
             <tr>
                 <td>format</td>
                 <td>(none)</td>
-                <td>See momentjs' docs for valid formats. Format also dictates which components are shown, e.g. MM/dd/YYYY will not display the time picker.</td>
+                <td>See <a href="http://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a> for valid formats. Format also dictates which components are shown, e.g. MM/dd/YYYY will not display the time picker.</td>
             </tr>
             <tr>
                 <td>hidden</td>


### PR DESCRIPTION
Whoops...seems like the documentation already referenced Moment.js but I have added the link in the format attribute.  Does it need more explanation further up the page?