### PR TITLE
Corrected markup

### DIFF
--- a/src/main/webapp/layout/navLinks.xhtml
+++ b/src/main/webapp/layout/navLinks.xhtml
@@ -164,9 +164,9 @@
                                     <b:navLink value="Slider" outcome="/jquery-ui/slider" iconAwesome="sliders"/>
                                     <b:navCommandLink value="AJAX actionListener" actionListener="#{messagesBean.info}"
                                                icon="tag" iconAlign="right" update="@form"/>
-                                    <b:messages />
                                 </b:tabLinks>
-                             </b:panel>
+				<b:messages />
+                            </b:panel>
                         </b:column>
                       </b:row>
                     </h:form>
@@ -185,8 +185,8 @@
                                     <b:navLink value="Slider" outcome="/jquery-ui/slider" iconAwesome="sliders"/>
                                     <b:navCommandLink value="AJAX actionListener" actionListener="&#35;{messagesBean.info}"
                                                icon="tag" iconAlign="right" update="@form"/>
-                                    <b:messages />
                                </b:tabLinks>
+			       <b:messages />
                          ]]></script>
                     </f:facet>
                 </b:panel>


### PR DESCRIPTION
The `<b:messages />` inside `b:tabLinks` was shown behind the tabs.