### PR TITLE
Updated BootsFaces version on page footer

### DIFF
--- a/src/main/webapp/applayout/navbarbottom.xhtml
+++ b/src/main/webapp/applayout/navbarbottom.xhtml
@@ -6,6 +6,6 @@
       xmlns:b="http://bootsfaces.net/ui">
 
     <b:navBar brand="&copy;2013-2017 TheCoder4Eu" brandHref="http://www.thecoder4.eu/" position="bottom" sticky="true">
-        <p class="navbar-text pull-right"><h:outputText value="BootsFaces v1.0.2-OSP on Mojarra 2.2.12, PrimeFaces 6.0, and OmniFaces 1.11" /></p>
+        <p class="navbar-text pull-right"><h:outputText value="BootsFaces v1.1.0-OSP-SNAPSHOT on Mojarra 2.2.12, PrimeFaces 6.0, and OmniFaces 1.11" /></p>
     </b:navBar>
 </ui:fragment>


### PR DESCRIPTION
It was confusing for people visiting the SNAPSHOT documentation (http://www3.bootsfaces.net/Showcase/) to see the current stable version there.

This value should be move to a properties file.